### PR TITLE
Implement Mixture-of-Hill model (GenJAX-native inference ver.) — Proposal 2 for Issue #20

### DIFF
--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -17,7 +17,7 @@ from genjax import Const  # type: ignore
 # Utilities
 # ------------------------------
 def hill(x, kd, n, eps=1e-6):
-    x = jnp.maximum(jnp.asarray(x, jnp.float32), eps)
+    x = jnp.maximum(x, eps)
     return 1.0 / (1.0 + (kd / x) ** n)
 
 
@@ -40,7 +40,7 @@ def mix_hill_vec(
     rate_n=2.0,
     sigma=0.02,
 ):
-    xs = jnp.asarray(xs)
+    xs = xs
     N = xs.shape[0]
     K = 3
 
@@ -214,7 +214,7 @@ def run_inference_genjax_only(
 
 def make_obs_from_y(y_obs):
     obs = ChoiceMap.empty()
-    obs = obs.at["y"].set(jnp.asarray(y_obs))
+    obs = obs.at["y"].set(y_obs)
     return obs
 
 

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -81,23 +81,51 @@ def hill_mixture_model(
 """Proposals using propose/assess to directly produce ChoiceMap for model.update."""
 
 
-# MH proposal for global params (Kd, n): independent gamma proposal at model addresses
-@gen
-def prop_globals(trace, *model_args):
-    chm_cur = trace.get_choices()
-    K = chm_cur["clusters/Kd"].shape[0]
+"""Random-walk proposals for globals (Kd, n) in log-space.
 
-    # Unpack model args to reuse prior hyperparams
-    # args = (xs, alpha, shape_kd, rate_kd, shape_n, rate_n, sigma)
-    shape_kd = model_args[2]
-    rate_kd = model_args[3]
-    shape_n = model_args[4]
-    rate_n = model_args[5]
+The prior-independent proposals led to poor mixing when data are abundant and
+noise is small. We switch to symmetric random-walk proposals in log-space and
+update parameters locally per-cluster and per-parameter to improve acceptance.
+"""
 
-    # Directly sample at model addresses so propose() returns a ChoiceMap usable by model.update
-    Kd_prop = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ "clusters/Kd"
-    n_prop = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ "clusters/n"
-    return None
+
+def _mh_rw_one(key, trace, model, address: str, idx: int, step: float):
+    """One MH random-walk update on log-parameter for a single index.
+
+    - address: one of "clusters/Kd" or "clusters/n"
+    - idx: which cluster index to update
+    - step: stddev of the additive noise in log-space
+
+    Uses model.update to compute the log target ratio; adds the Hastings
+    correction (z' - z) arising from the exp transform when proposing in
+    log-space.
+    """
+    argdiffs = Diff.no_change(trace.get_args())
+
+    ch = trace.get_choices()
+    cur_vec = ch[address]
+    x_cur = cur_vec[idx]
+    z_cur = jnp.log(jnp.maximum(x_cur, 1e-20))
+
+    key, sub = jax.random.split(key)
+    z_prop = z_cur + step * jax.random.normal(sub)
+    x_prop = jnp.exp(z_prop)
+
+    prop_vec = cur_vec.at[idx].set(x_prop)
+    prop_cm = ChoiceMap.empty()
+    prop_cm = prop_cm.at[address].set(prop_vec)
+
+    key, sub = jax.random.split(key)
+    new_trace, model_logw, _, _ = model.update(sub, trace, prop_cm, argdiffs)
+
+    # Hastings correction for proposing in log-space: log q(x|x') - log q(x'|x) = z' - z
+    delta_log_q = z_prop - z_cur
+    alpha = model_logw + delta_log_q
+
+    key, sub = jax.random.split(key)
+    accept = jnp.log(jax.random.uniform(sub)) < alpha
+    out_trace = jax.lax.cond(accept, lambda _: new_trace, lambda _: trace, operand=None)
+    return key, out_trace
 
 
 # Gibbs-style proposal for weights using propose/assess directly on model address
@@ -151,31 +179,23 @@ def prop_z(trace, *model_args):
 # ------------------------------
 
 
-def mh_step_globals(key, trace, model, _step_kd: float, _step_n: float):
-    """MH step for (Kd, n) using independent gamma proposals at model addresses.
-    Uses proposal.propose/assess + model.update to compute the acceptance ratio.
+def mh_step_globals_rw(key, trace, model, step_kd: float, step_n: float):
+    """One sweep of local RW updates over all clusters for Kd and n.
+
+    Proposes in log-space with Normal(0, step^2) increments and includes the
+    Hastings correction. Updates K components sequentially using a JAX fori_loop.
     """
-    argdiffs = Diff.no_change(trace.get_args())
+    ch = trace.get_choices()
+    K = ch["clusters/Kd"].shape[0]
 
-    model_args = trace.get_args()
+    def body(i, carry):
+        key_s, trace_s = carry
+        key_s, trace_s = _mh_rw_one(key_s, trace_s, model, "clusters/Kd", i, step_kd)
+        key_s, trace_s = _mh_rw_one(key_s, trace_s, model, "clusters/n", i, step_n)
+        return (key_s, trace_s)
 
-    # Forward proposal: returns ChoiceMap aligned with model addresses
-    key, sub = jax.random.split(key)
-    fwd_choices, fwd_weight, _ = prop_globals.propose(sub, (trace, *model_args))
-
-    # Update model with proposed choices
-    key, sub = jax.random.split(key)
-    new_trace, model_logw, _, discard = model.update(sub, trace, fwd_choices, argdiffs)
-
-    # Backward weight (likelihood of returning to old under proposal)
-    bwd_weight, _ = prop_globals.assess(discard, (new_trace, *model_args))
-
-    # MH acceptance ratio
-    alpha = model_logw - fwd_weight + bwd_weight
-    key, sub = jax.random.split(key)
-    accept = jnp.log(jax.random.uniform(sub)) < alpha
-    out_trace = jax.lax.cond(accept, lambda _: new_trace, lambda _: trace, operand=None)
-    return key, out_trace, accept, alpha
+    key, trace = jax.lax.fori_loop(0, K, body, (key, trace))
+    return key, trace
 
 
 def mh_step_weights(key, trace, model, alpha):
@@ -252,7 +272,7 @@ def run_inference(
     def _step(carry, i):
         key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, cnt_s = carry
 
-        key_s, trace_s, _, _ = mh_step_globals(
+        key_s, trace_s = mh_step_globals_rw(
             key_s, trace_s, model, mh_step_kd, mh_step_n
         )
         # Always update z and weights
@@ -299,7 +319,7 @@ def make_obs_from_y(y_obs):
 
 
 def test_main():
-    key = jax.random.PRNGKey(314159)
+    key = jax.random.PRNGKey(123)
     xs = jnp.linspace(1.0, 100.0, 1000)
     alpha = jnp.ones(3)
     args = (xs, alpha, 100.0, 5.0, 4.0, 2.0, 0.05)
@@ -320,11 +340,11 @@ def test_main():
         hill_mixture_model,
         args,
         obs,
-        n_rounds=2000,
+        n_rounds=10000,
         mh_step_kd=0.03,
         mh_step_n=0.03,
         burn_in=1000,
-        thin=20,
+        thin=5,
     )
 
     ch = tr_post.get_choices()

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -45,8 +45,9 @@ def mix_hill_vec(
     K = 3
 
     w = dirichlet(alpha) @ "weights"  # (K,)
-    Kd = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ ("clusters", "Kd")  # (K,)
-    n = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ ("clusters", "n")  # (K,)
+    # Use flat string addresses to avoid mixed key types in pytrees
+    Kd = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ "clusters/Kd"  # (K,)
+    n = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ "clusters/n"  # (K,)
 
     z = categorical(w, sample_shape=Const((N,))) @ "z"  # (N,)
 
@@ -119,8 +120,8 @@ def mh_step_globals(key, trace, model, step_kd: float, step_n: float):
     """(Kd, n) を対称 RW 提案で MH。提案は simulate で取り、assess は使わない。"""
     argdiffs = Diff.no_change(trace.get_args())
     chm_cur = trace.get_choices()
-    Kd_cur = chm_cur["clusters", "Kd"]
-    n_cur = chm_cur["clusters", "n"]
+    Kd_cur = chm_cur["clusters/Kd"]
+    n_cur = chm_cur["clusters/n"]
 
     # 対称 RW 提案（log 空間）
     key, sub = jax.random.split(key)
@@ -130,8 +131,8 @@ def mh_step_globals(key, trace, model, step_kd: float, step_n: float):
 
     # 提案をモデルに適用
     chm = ChoiceMap.empty()
-    chm = chm.at["clusters", "Kd"].set(Kd_prop)
-    chm = chm.at["clusters", "n"].set(n_prop)
+    chm = chm.at["clusters/Kd"].set(Kd_prop)
+    chm = chm.at["clusters/n"].set(n_prop)
 
     key, sub = jax.random.split(key)
     new_trace, model_logw, _, _ = model.update(sub, trace, chm, argdiffs)
@@ -139,7 +140,8 @@ def mh_step_globals(key, trace, model, step_kd: float, step_n: float):
     # 対称提案なので fwd/bwd は 0、受容確率は model_logw のみで決まる
     key, sub = jax.random.split(key)
     accept = jnp.log(jax.random.uniform(sub)) < model_logw
-    out_trace = new_trace if bool(accept) else trace
+    # Use lax.cond to select traces under JIT/scan
+    out_trace = jax.lax.cond(accept, lambda _: new_trace, lambda _: trace, operand=None)
     return key, out_trace, accept, model_logw
 
 
@@ -163,8 +165,8 @@ def gibbs_step_z(key, trace, model, sigma):
     xs = trace.get_args()[0]
     y_vec = ch["y"]
     w = ch["weights"]
-    Kd = ch["clusters", "Kd"]
-    n = ch["clusters", "n"]
+    Kd = ch["clusters/Kd"]
+    n = ch["clusters/n"]
 
     key, sub = jax.random.split(key)
     z_new = gibbs_z_prop.simulate(sub, (xs, y_vec, w, Kd, n, sigma)).get_retval()
@@ -198,12 +200,27 @@ def run_inference_genjax_only(
     alpha = model_args[1]
     sigma = model_args[-1]
 
-    for _ in range(n_rounds):
-        key, trace, _, _ = mh_step_globals(key, trace, model, mh_step_kd, mh_step_n)
-        if do_gibbs_z:
-            key, trace = gibbs_step_z(key, trace, model, sigma)
-        if do_gibbs_w:
-            key, trace = gibbs_step_weights(key, trace, model, alpha)
+    # JIT-friendly loop with lax.scan; guard Gibbs steps via lax.cond
+    def _step(carry, _):
+        key_s, trace_s = carry
+        key_s, trace_s, _, _ = mh_step_globals(
+            key_s, trace_s, model, mh_step_kd, mh_step_n
+        )
+        key_s, trace_s = jax.lax.cond(
+            do_gibbs_z,
+            lambda kt: gibbs_step_z(kt[0], kt[1], model, sigma),
+            lambda kt: kt,
+            (key_s, trace_s),
+        )
+        key_s, trace_s = jax.lax.cond(
+            do_gibbs_w,
+            lambda kt: gibbs_step_weights(kt[0], kt[1], model, alpha),
+            lambda kt: kt,
+            (key_s, trace_s),
+        )
+        return (key_s, trace_s), None
+
+    (key, trace), _ = jax.lax.scan(_step, (key, trace), xs=None, length=n_rounds)
     return trace
 
 
@@ -228,8 +245,8 @@ def test_main():
     tr_true = mix_hill_vec.simulate(sub, args)
     ch_true = tr_true.get_choices()
     print("[truth] weights:", ch_true["weights"])
-    print("[truth] Kd:", ch_true["clusters", "Kd"])
-    print("[truth] n :", ch_true["clusters", "n"])
+    print("[truth] Kd:", ch_true["clusters/Kd"])
+    print("[truth] n :", ch_true["clusters/n"])
 
     y_obs = ch_true["y"]
     obs = make_obs_from_y(y_obs)
@@ -249,8 +266,8 @@ def test_main():
 
     ch = tr_post.get_choices()
     print("[posterior] weights:", ch["weights"])
-    print("[posterior] Kd     :", ch["clusters", "Kd"])
-    print("[posterior] n      :", ch["clusters", "n"])
+    print("[posterior] Kd     :", ch["clusters/Kd"])
+    print("[posterior] n      :", ch["clusters/n"])
     print("z head:", ch["z"][:10])
 
     assert jnp.all(ch["weights"] >= 0) and jnp.isclose(

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -71,20 +71,21 @@ def mix_hill_vec(
 # ------------------------------
 
 
-# MH proposal for (Kd, n): log-space symmetric RW
+# MH proposal for a single (Kd, n): log-space symmetric RW (row-wise)
 @gen
-def rw_globals_prop(Kd_cur, n_cur, step_kd: float, step_n: float):
-    logKd = jnp.log(Kd_cur)
-    logn = jnp.log(n_cur)
+def rw_globals_prop_row(Kd_cur_single, n_cur_single, step_kd: float, step_n: float):
+    logKd = jnp.log(Kd_cur_single)
+    logn = jnp.log(n_cur_single)
 
-    eps_kd = (
-        normal.vmap()(jnp.zeros_like(logKd), step_kd * jnp.ones_like(logKd)) @ "eps_kd"
-    )
-    eps_n = normal.vmap()(jnp.zeros_like(logn), step_n * jnp.ones_like(logn)) @ "eps_n"
+    eps_kd = normal(0.0, step_kd) @ "eps_kd"
+    eps_n = normal(0.0, step_n) @ "eps_n"
 
     Kd_prop = jnp.exp(logKd + eps_kd)
     n_prop = jnp.exp(logn + eps_n)
     return (Kd_prop, n_prop)
+
+# Define vmapped wrapper once and reuse
+rw_globals_prop_row_vmap = rw_globals_prop_row.vmap(in_axes=(0, 0, None, None))
 
 
 # Gibbs proposal for weights: Dirichlet(alpha + counts(z))
@@ -97,18 +98,17 @@ def gibbs_weights_prop(alpha, z_vec):
     return w_new
 
 
-# Gibbs proposal for z (collapsed) 一括
+# Gibbs proposal for a single z_i (collapsed, row-wise)
 @gen
-def gibbs_z_prop(xs, y_vec, weights, Kd, n, sigma):
-    def logits_row(xi, yi):
-        mu_k = hill(jnp.full((3,), xi), Kd, n)  # (3,)
-        ll_k = -0.5 * (jnp.log(2.0 * jnp.pi * sigma**2) + ((yi - mu_k) / sigma) ** 2)
-        return jnp.log(weights + 1e-20) + ll_k  # (3,)
+def gibbs_z_row_prop(xi, yi, weights, Kd, n, sigma):
+    mu_k = hill(jnp.full((3,), xi), Kd, n)  # (3,)
+    ll_k = -0.5 * (jnp.log(2.0 * jnp.pi * sigma**2) + ((yi - mu_k) / sigma) ** 2)
+    logits = jnp.log(weights + 1e-20) + ll_k  # (3,)
+    z_i = categorical(logits) @ "z_i"  # scalar index
+    return z_i
 
-    logits = jax.vmap(logits_row)(xs, y_vec)  # (N, 3)
-    # ★ 行ごとの独立カテゴリカルにする（バッチ化）
-    z = categorical.vmap()(logits) @ "z"  # (N,)
-    return z
+# Define vmapped wrapper once and reuse
+gibbs_z_row_prop_vmap = gibbs_z_row_prop.vmap(in_axes=(0, 0, None, None, None, None))
 
 
 # ------------------------------
@@ -123,9 +123,9 @@ def mh_step_globals(key, trace, model, step_kd: float, step_n: float):
     Kd_cur = chm_cur["clusters/Kd"]
     n_cur = chm_cur["clusters/n"]
 
-    # 対称 RW 提案（log 空間）
+    # 対称 RW 提案（log 空間）: 外側で vmap 適用
     key, sub = jax.random.split(key)
-    Kd_prop, n_prop = rw_globals_prop.simulate(
+    Kd_prop, n_prop = rw_globals_prop_row_vmap.simulate(
         sub, (Kd_cur, n_cur, step_kd, step_n)
     ).get_retval()
 
@@ -169,7 +169,10 @@ def gibbs_step_z(key, trace, model, sigma):
     n = ch["clusters/n"]
 
     key, sub = jax.random.split(key)
-    z_new = gibbs_z_prop.simulate(sub, (xs, y_vec, w, Kd, n, sigma)).get_retval()
+    # 行方向に独立なカテゴリカルを外側で vmap
+    z_new = gibbs_z_row_prop_vmap.simulate(
+        sub, (xs, y_vec, w, Kd, n, sigma)
+    ).get_retval()
     # dtype/shape を明示（int32, (N,)）
     z_new = z_new.astype(jnp.int32).reshape(y_vec.shape)
 

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+"""
+GenJAX-only inference combinators for Mixture of Hill functions (K=3, traceをproposalに渡さない版)
+"""
+
+import jax
+import jax.numpy as jnp
+
+import genjax
+from genjax import gen, normal, gamma, dirichlet, categorical  # type: ignore
+from genjax import ChoiceMap  # type: ignore
+from genjax._src.core.compiler.interpreters.incremental import Diff  # type: ignore
+from genjax import Const  # type: ignore
+
+
+# ------------------------------
+# Utilities
+# ------------------------------
+def hill(x, kd, n, eps=1e-6):
+    x = jnp.maximum(jnp.asarray(x, jnp.float32), eps)
+    return 1.0 / (1.0 + (kd / x) ** n)
+
+
+def log_normal_pdf(y, mu, sigma):
+    return -0.5 * (
+        jnp.log(2.0 * jnp.pi) + 2.0 * jnp.log(sigma) + ((y - mu) / sigma) ** 2
+    )
+
+
+# ------------------------------
+# Generative model (vectorized addresses)
+# ------------------------------
+@gen
+def mix_hill_vec(
+    xs,
+    alpha,
+    shape_kd=100.0,
+    rate_kd=5.0,
+    shape_n=4.0,
+    rate_n=2.0,
+    sigma=0.02,
+):
+    xs = jnp.asarray(xs)
+    N = xs.shape[0]
+    K = 3
+
+    w = dirichlet(alpha) @ "weights"  # (K,)
+    Kd = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ ("clusters", "Kd")  # (K,)
+    n = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ ("clusters", "n")  # (K,)
+
+    z = categorical(w, sample_shape=Const((N,))) @ "z"  # (N,)
+
+    xs_safe = jnp.maximum(xs, 1e-6)
+    mu_all = jnp.stack(
+        [
+            1.0 / (1.0 + (Kd[0] / xs_safe) ** n[0]),
+            1.0 / (1.0 + (Kd[1] / xs_safe) ** n[1]),
+            1.0 / (1.0 + (Kd[2] / xs_safe) ** n[2]),
+        ],
+        axis=1,
+    )  # (N, K)
+    mu = mu_all[jnp.arange(N), z]  # (N,)
+
+    y = normal(mu, sigma) @ "y"
+    return y
+
+
+# ------------------------------
+# Proposals（traceは受け取らない）
+# ------------------------------
+
+
+# MH proposal for (Kd, n): log-space symmetric RW
+@gen
+def rw_globals_prop(Kd_cur, n_cur, step_kd: float, step_n: float):
+    logKd = jnp.log(Kd_cur)
+    logn = jnp.log(n_cur)
+
+    eps_kd = (
+        normal.vmap()(jnp.zeros_like(logKd), step_kd * jnp.ones_like(logKd)) @ "eps_kd"
+    )
+    eps_n = normal.vmap()(jnp.zeros_like(logn), step_n * jnp.ones_like(logn)) @ "eps_n"
+
+    Kd_prop = jnp.exp(logKd + eps_kd)
+    n_prop = jnp.exp(logn + eps_n)
+    return (Kd_prop, n_prop)
+
+
+# Gibbs proposal for weights: Dirichlet(alpha + counts(z))
+@gen
+def gibbs_weights_prop(alpha, z_vec):
+    K = alpha.shape[0]
+    counts = jnp.bincount(z_vec, length=K)
+    post_alpha = alpha + counts
+    w_new = dirichlet(post_alpha) @ "w_new"
+    return w_new
+
+
+# Gibbs proposal for z (collapsed) 一括
+@gen
+def gibbs_z_prop(xs, y_vec, weights, Kd, n, sigma):
+    def logits_row(xi, yi):
+        mu_k = hill(jnp.full((3,), xi), Kd, n)  # (3,)
+        ll_k = -0.5 * (jnp.log(2.0 * jnp.pi * sigma**2) + ((yi - mu_k) / sigma) ** 2)
+        return jnp.log(weights + 1e-20) + ll_k  # (3,)
+
+    logits = jax.vmap(logits_row)(xs, y_vec)  # (N, 3)
+    # ★ 行ごとの独立カテゴリカルにする（バッチ化）
+    z = categorical.vmap()(logits) @ "z"  # (N,)
+    return z
+
+
+# ------------------------------
+# Single-step kernels using propose/assess + model.update
+# ------------------------------
+
+
+def mh_step_globals(key, trace, model, step_kd: float, step_n: float):
+    """(Kd, n) を対称 RW 提案で MH。提案は simulate で取り、assess は使わない。"""
+    argdiffs = Diff.no_change(trace.get_args())
+    chm_cur = trace.get_choices()
+    Kd_cur = chm_cur["clusters", "Kd"]
+    n_cur = chm_cur["clusters", "n"]
+
+    # 対称 RW 提案（log 空間）
+    key, sub = jax.random.split(key)
+    Kd_prop, n_prop = rw_globals_prop.simulate(
+        sub, (Kd_cur, n_cur, step_kd, step_n)
+    ).get_retval()
+
+    # 提案をモデルに適用
+    chm = ChoiceMap.empty()
+    chm = chm.at["clusters", "Kd"].set(Kd_prop)
+    chm = chm.at["clusters", "n"].set(n_prop)
+
+    key, sub = jax.random.split(key)
+    new_trace, model_logw, _, _ = model.update(sub, trace, chm, argdiffs)
+
+    # 対称提案なので fwd/bwd は 0、受容確率は model_logw のみで決まる
+    key, sub = jax.random.split(key)
+    accept = jnp.log(jax.random.uniform(sub)) < model_logw
+    out_trace = new_trace if bool(accept) else trace
+    return key, out_trace, accept, model_logw
+
+
+def gibbs_step_weights(key, trace, model, alpha):
+    """weights | z はディリクレ共役。simulate でサンプルして確定 update。"""
+    argdiffs = Diff.no_change(trace.get_args())
+    z_vec = trace.get_choices()["z"]
+
+    key, sub = jax.random.split(key)
+    w_new = gibbs_weights_prop.simulate(sub, (alpha, z_vec)).get_retval()
+
+    chm = ChoiceMap.empty().at["weights"].set(w_new)
+    key, sub = jax.random.split(key)
+    new_trace, _, _, _ = model.update(sub, trace, chm, argdiffs)
+    return key, new_trace
+
+
+def gibbs_step_z(key, trace, model, sigma):
+    argdiffs = Diff.no_change(trace.get_args())
+    ch = trace.get_choices()
+    xs = trace.get_args()[0]
+    y_vec = ch["y"]
+    w = ch["weights"]
+    Kd = ch["clusters", "Kd"]
+    n = ch["clusters", "n"]
+
+    key, sub = jax.random.split(key)
+    z_new = gibbs_z_prop.simulate(sub, (xs, y_vec, w, Kd, n, sigma)).get_retval()
+    # dtype/shape を明示（int32, (N,)）
+    z_new = z_new.astype(jnp.int32).reshape(y_vec.shape)
+
+    chm = ChoiceMap.empty().at["z"].set(z_new)
+    key, sub = jax.random.split(key)
+    new_trace, _, _, _ = model.update(sub, trace, chm, argdiffs)
+    return key, new_trace
+
+
+# ------------------------------
+# Full inference loop
+# ------------------------------
+
+
+def run_inference_genjax_only(
+    key,
+    model,
+    model_args,
+    observations,
+    n_rounds=200,
+    mh_step_kd=0.03,
+    mh_step_n=0.03,
+    do_gibbs_z=True,
+    do_gibbs_w=True,
+):
+    key, sub = jax.random.split(key)
+    trace, _ = model.importance(sub, observations, model_args)
+    alpha = model_args[1]
+    sigma = model_args[-1]
+
+    for _ in range(n_rounds):
+        key, trace, _, _ = mh_step_globals(key, trace, model, mh_step_kd, mh_step_n)
+        if do_gibbs_z:
+            key, trace = gibbs_step_z(key, trace, model, sigma)
+        if do_gibbs_w:
+            key, trace = gibbs_step_weights(key, trace, model, alpha)
+    return trace
+
+
+# ------------------------------
+# Helpers / pytest demo
+# ------------------------------
+
+
+def make_obs_from_y(y_obs):
+    obs = ChoiceMap.empty()
+    obs = obs.at["y"].set(jnp.asarray(y_obs))
+    return obs
+
+
+def test_main():
+    key = jax.random.PRNGKey(314159)
+    xs = jnp.linspace(1.0, 100.0, 1000)
+    alpha = jnp.ones(3)
+    args = (xs, alpha, 100.0, 5.0, 4.0, 2.0, 0.05)
+
+    key, sub = jax.random.split(key)
+    tr_true = mix_hill_vec.simulate(sub, args)
+    ch_true = tr_true.get_choices()
+    print("[truth] weights:", ch_true["weights"])
+    print("[truth] Kd:", ch_true["clusters", "Kd"])
+    print("[truth] n :", ch_true["clusters", "n"])
+
+    y_obs = ch_true["y"]
+    obs = make_obs_from_y(y_obs)
+
+    key, sub = jax.random.split(key)
+    tr_post = run_inference_genjax_only(
+        sub,
+        mix_hill_vec,
+        args,
+        obs,
+        n_rounds=2000,
+        mh_step_kd=0.03,
+        mh_step_n=0.03,
+        do_gibbs_z=True,
+        do_gibbs_w=True,
+    )
+
+    ch = tr_post.get_choices()
+    print("[posterior] weights:", ch["weights"])
+    print("[posterior] Kd     :", ch["clusters", "Kd"])
+    print("[posterior] n      :", ch["clusters", "n"])
+    print("z head:", ch["z"][:10])
+
+    assert jnp.all(ch["weights"] >= 0) and jnp.isclose(
+        jnp.sum(ch["weights"]), 1.0, atol=1e-4
+    )

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
-"""
-GenJAX-only inference combinators for Mixture of Hill functions (K=3, traceをproposalに渡さない版)
-"""
 
 import jax
 import jax.numpy as jnp
 
 import genjax
-from genjax import gen, normal, gamma, dirichlet, categorical  # type: ignore
+from genjax import gen, normal, gamma, dirichlet, categorical, mix  # type: ignore
 from genjax import ChoiceMap  # type: ignore
 from genjax._src.core.compiler.interpreters.incremental import Diff  # type: ignore
 from genjax import Const  # type: ignore
@@ -28,10 +25,19 @@ def log_normal_pdf(y, mu, sigma):
 
 
 # ------------------------------
-# Generative model (vectorized addresses)
+# Components (top-level)
 # ------------------------------
 @gen
-def mix_hill_vec(
+def hill_mu_component(xi, kd, n_k):
+    mu = hill(xi, kd, n_k)
+    return mu
+
+
+# ------------------------------
+# Generative model (vectorized with mix combinator)
+# ------------------------------
+@gen
+def hill_mixture_model(
     xs,
     alpha,
     shape_kd=100.0,
@@ -40,17 +46,87 @@ def mix_hill_vec(
     rate_n=2.0,
     sigma=0.02,
 ):
-    xs = xs
-    N = xs.shape[0]
     K = 3
 
+    # Global parameters
     w = dirichlet(alpha) @ "weights"  # (K,)
-    # Use flat string addresses to avoid mixed key types in pytrees
     Kd = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ "clusters/Kd"  # (K,)
     n = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ "clusters/n"  # (K,)
 
-    z = categorical(w, sample_shape=Const((N,))) @ "z"  # (N,)
+    # Build 3-component mixture and vmap over observations
+    logits = jnp.log(w + 1e-20)
+    mix3 = mix(hill_mu_component, hill_mu_component, hill_mu_component)
+    mix3_vm = mix3.vmap(
+        in_axes=(
+            None,  # logits shared across rows
+            (0, None, None),  # args for comp 1: (xs, Kd[0], n[0])
+            (0, None, None),  # args for comp 2
+            (0, None, None),  # args for comp 3
+        )
+    )
 
+    mu_vec = (
+        mix3_vm(logits, (xs, Kd[0], n[0]), (xs, Kd[1], n[1]), (xs, Kd[2], n[2]))
+        @ "y_mix"
+    )
+    y = normal(mu_vec, sigma) @ "y"
+    return y
+
+
+# ------------------------------
+# Proposals
+# ------------------------------
+
+
+"""Proposals using propose/assess to directly produce ChoiceMap for model.update."""
+
+
+# MH proposal for global params (Kd, n): independent gamma proposal at model addresses
+@gen
+def prop_globals(trace, *model_args):
+    chm_cur = trace.get_choices()
+    K = chm_cur["clusters/Kd"].shape[0]
+
+    # Unpack model args to reuse prior hyperparams
+    # args = (xs, alpha, shape_kd, rate_kd, shape_n, rate_n, sigma)
+    shape_kd = model_args[2]
+    rate_kd = model_args[3]
+    shape_n = model_args[4]
+    rate_n = model_args[5]
+
+    # Directly sample at model addresses so propose() returns a ChoiceMap usable by model.update
+    Kd_prop = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ "clusters/Kd"
+    n_prop = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ "clusters/n"
+    return None
+
+
+# Gibbs-style proposal for weights using propose/assess directly on model address
+@gen
+def prop_weights(trace, *model_args):
+    ch = trace.get_choices()
+    z_vec = ch["y_mix", "mixture_component"]
+    K = ch["weights"].shape[0]
+    alpha = model_args[1]
+    counts = jnp.bincount(z_vec, length=K)
+    post_alpha = alpha + counts
+    _ = dirichlet(post_alpha) @ "weights"
+    return None
+
+
+@gen
+def prop_z(trace, *model_args):
+    """Propose z vector at ("y_mix","mixture_component") using collapsed categorical per row.
+    Computes per-row logits ~ log w_k + log p(y_i | x_i, Kd_k, n_k).
+    """
+    ch = trace.get_choices()
+    xs = trace.get_args()[0]
+    y_vec = ch["y"]
+    w = ch["weights"]  # (K,)
+    Kd = ch["clusters/Kd"]  # (K,)
+    n = ch["clusters/n"]  # (K,)
+    sigma = model_args[-1]
+
+    # Compute per-row logits (N,K)
     xs_safe = jnp.maximum(xs, 1e-6)
     mu_all = jnp.stack(
         [
@@ -60,55 +136,14 @@ def mix_hill_vec(
         ],
         axis=1,
     )  # (N, K)
-    mu = mu_all[jnp.arange(N), z]  # (N,)
+    ll = -0.5 * (
+        jnp.log(2.0 * jnp.pi * sigma**2) + ((y_vec[:, None] - mu_all) / sigma) ** 2
+    )
+    logits = jnp.log(w + 1e-20)[None, :] + ll  # (N,K)
 
-    y = normal(mu, sigma) @ "y"
-    return y
-
-
-# ------------------------------
-# Proposals（traceは受け取らない）
-# ------------------------------
-
-
-# MH proposal for a single (Kd, n): log-space symmetric RW (row-wise)
-@gen
-def rw_globals_prop_row(Kd_cur_single, n_cur_single, step_kd: float, step_n: float):
-    logKd = jnp.log(Kd_cur_single)
-    logn = jnp.log(n_cur_single)
-
-    eps_kd = normal(0.0, step_kd) @ "eps_kd"
-    eps_n = normal(0.0, step_n) @ "eps_n"
-
-    Kd_prop = jnp.exp(logKd + eps_kd)
-    n_prop = jnp.exp(logn + eps_n)
-    return (Kd_prop, n_prop)
-
-# Define vmapped wrapper once and reuse
-rw_globals_prop_row_vmap = rw_globals_prop_row.vmap(in_axes=(0, 0, None, None))
-
-
-# Gibbs proposal for weights: Dirichlet(alpha + counts(z))
-@gen
-def gibbs_weights_prop(alpha, z_vec):
-    K = alpha.shape[0]
-    counts = jnp.bincount(z_vec, length=K)
-    post_alpha = alpha + counts
-    w_new = dirichlet(post_alpha) @ "w_new"
-    return w_new
-
-
-# Gibbs proposal for a single z_i (collapsed, row-wise)
-@gen
-def gibbs_z_row_prop(xi, yi, weights, Kd, n, sigma):
-    mu_k = hill(jnp.full((3,), xi), Kd, n)  # (3,)
-    ll_k = -0.5 * (jnp.log(2.0 * jnp.pi * sigma**2) + ((yi - mu_k) / sigma) ** 2)
-    logits = jnp.log(weights + 1e-20) + ll_k  # (3,)
-    z_i = categorical(logits) @ "z_i"  # scalar index
-    return z_i
-
-# Define vmapped wrapper once and reuse
-gibbs_z_row_prop_vmap = gibbs_z_row_prop.vmap(in_axes=(0, 0, None, None, None, None))
+    # Sample vector of indices directly at the model's mixture address
+    _ = categorical(logits) @ ("y_mix", "mixture_component")
+    return None
 
 
 # ------------------------------
@@ -116,70 +151,74 @@ gibbs_z_row_prop_vmap = gibbs_z_row_prop.vmap(in_axes=(0, 0, None, None, None, N
 # ------------------------------
 
 
-def mh_step_globals(key, trace, model, step_kd: float, step_n: float):
-    """(Kd, n) を対称 RW 提案で MH。提案は simulate で取り、assess は使わない。"""
+def mh_step_globals(key, trace, model, _step_kd: float, _step_n: float):
+    """MH step for (Kd, n) using independent gamma proposals at model addresses.
+    Uses proposal.propose/assess + model.update to compute the acceptance ratio.
+    """
     argdiffs = Diff.no_change(trace.get_args())
-    chm_cur = trace.get_choices()
-    Kd_cur = chm_cur["clusters/Kd"]
-    n_cur = chm_cur["clusters/n"]
 
-    # 対称 RW 提案（log 空間）: 外側で vmap 適用
+    model_args = trace.get_args()
+
+    # Forward proposal: returns ChoiceMap aligned with model addresses
     key, sub = jax.random.split(key)
-    Kd_prop, n_prop = rw_globals_prop_row_vmap.simulate(
-        sub, (Kd_cur, n_cur, step_kd, step_n)
-    ).get_retval()
+    fwd_choices, fwd_weight, _ = prop_globals.propose(sub, (trace, *model_args))
 
-    # 提案をモデルに適用
-    chm = ChoiceMap.empty()
-    chm = chm.at["clusters/Kd"].set(Kd_prop)
-    chm = chm.at["clusters/n"].set(n_prop)
-
+    # Update model with proposed choices
     key, sub = jax.random.split(key)
-    new_trace, model_logw, _, _ = model.update(sub, trace, chm, argdiffs)
+    new_trace, model_logw, _, discard = model.update(sub, trace, fwd_choices, argdiffs)
 
-    # 対称提案なので fwd/bwd は 0、受容確率は model_logw のみで決まる
+    # Backward weight (likelihood of returning to old under proposal)
+    bwd_weight, _ = prop_globals.assess(discard, (new_trace, *model_args))
+
+    # MH acceptance ratio
+    alpha = model_logw - fwd_weight + bwd_weight
     key, sub = jax.random.split(key)
-    accept = jnp.log(jax.random.uniform(sub)) < model_logw
-    # Use lax.cond to select traces under JIT/scan
+    accept = jnp.log(jax.random.uniform(sub)) < alpha
     out_trace = jax.lax.cond(accept, lambda _: new_trace, lambda _: trace, operand=None)
-    return key, out_trace, accept, model_logw
+    return key, out_trace, accept, alpha
 
 
-def gibbs_step_weights(key, trace, model, alpha):
-    """weights | z はディリクレ共役。simulate でサンプルして確定 update。"""
+def mh_step_weights(key, trace, model, alpha):
+    """Update weights | z via Dirichlet conditional using propose/assess.
+    This is a Gibbs-style move; acceptance should be ~1 in theory, but we still
+    run the generic MH accept/reject for consistency.
+    """
     argdiffs = Diff.no_change(trace.get_args())
-    z_vec = trace.get_choices()["z"]
+    model_args = trace.get_args()
 
     key, sub = jax.random.split(key)
-    w_new = gibbs_weights_prop.simulate(sub, (alpha, z_vec)).get_retval()
+    fwd_choices, fwd_weight, _ = prop_weights.propose(sub, (trace, *model_args))
 
-    chm = ChoiceMap.empty().at["weights"].set(w_new)
     key, sub = jax.random.split(key)
-    new_trace, _, _, _ = model.update(sub, trace, chm, argdiffs)
-    return key, new_trace
+    new_trace, model_logw, _, discard = model.update(sub, trace, fwd_choices, argdiffs)
+
+    bwd_weight, _ = prop_weights.assess(discard, (new_trace, *model_args))
+
+    alpha_log = model_logw - fwd_weight + bwd_weight
+    key, sub = jax.random.split(key)
+    accept = jnp.log(jax.random.uniform(sub)) < alpha_log
+    out_trace = jax.lax.cond(accept, lambda _: new_trace, lambda _: trace, operand=None)
+    return key, out_trace
 
 
-def gibbs_step_z(key, trace, model, sigma):
+def mh_step_z(key, trace, model, sigma):
+    """Update z | rest using collapsed categorical via propose/assess."""
     argdiffs = Diff.no_change(trace.get_args())
-    ch = trace.get_choices()
-    xs = trace.get_args()[0]
-    y_vec = ch["y"]
-    w = ch["weights"]
-    Kd = ch["clusters/Kd"]
-    n = ch["clusters/n"]
+    model_args = trace.get_args()
 
     key, sub = jax.random.split(key)
-    # 行方向に独立なカテゴリカルを外側で vmap
-    z_new = gibbs_z_row_prop_vmap.simulate(
-        sub, (xs, y_vec, w, Kd, n, sigma)
-    ).get_retval()
-    # dtype/shape を明示（int32, (N,)）
-    z_new = z_new.astype(jnp.int32).reshape(y_vec.shape)
+    fwd_choices, fwd_weight, _ = prop_z.propose(sub, (trace, *model_args))
 
-    chm = ChoiceMap.empty().at["z"].set(z_new)
     key, sub = jax.random.split(key)
-    new_trace, _, _, _ = model.update(sub, trace, chm, argdiffs)
-    return key, new_trace
+    new_trace, model_logw, _, discard = model.update(sub, trace, fwd_choices, argdiffs)
+
+    bwd_weight, _ = prop_z.assess(discard, (new_trace, *model_args))
+
+    alpha = model_logw - fwd_weight + bwd_weight
+    key, sub = jax.random.split(key)
+    accept = jnp.log(jax.random.uniform(sub)) < alpha
+    out_trace = jax.lax.cond(accept, lambda _: new_trace, lambda _: trace, operand=None)
+    return key, out_trace
 
 
 # ------------------------------
@@ -187,7 +226,7 @@ def gibbs_step_z(key, trace, model, sigma):
 # ------------------------------
 
 
-def run_inference_genjax_only(
+def run_inference(
     key,
     model,
     model_args,
@@ -195,36 +234,57 @@ def run_inference_genjax_only(
     n_rounds=200,
     mh_step_kd=0.03,
     mh_step_n=0.03,
-    do_gibbs_z=True,
-    do_gibbs_w=True,
+    burn_in: int = 0,
+    thin: int = 1,
 ):
     key, sub = jax.random.split(key)
     trace, _ = model.importance(sub, observations, model_args)
     alpha = model_args[1]
     sigma = model_args[-1]
 
-    # JIT-friendly loop with lax.scan; guard Gibbs steps via lax.cond
-    def _step(carry, _):
-        key_s, trace_s = carry
+    # Prepare accumulators for posterior means (weights, Kd, n)
+    ch0 = trace.get_choices()
+    sum_w = jnp.zeros_like(ch0["weights"])  # (K,)
+    sum_kd = jnp.zeros_like(ch0["clusters/Kd"])  # (K,)
+    sum_n = jnp.zeros_like(ch0["clusters/n"])  # (K,)
+    count = jnp.array(0, dtype=jnp.int32)
+
+    def _step(carry, i):
+        key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, cnt_s = carry
+
         key_s, trace_s, _, _ = mh_step_globals(
             key_s, trace_s, model, mh_step_kd, mh_step_n
         )
-        key_s, trace_s = jax.lax.cond(
-            do_gibbs_z,
-            lambda kt: gibbs_step_z(kt[0], kt[1], model, sigma),
-            lambda kt: kt,
-            (key_s, trace_s),
-        )
-        key_s, trace_s = jax.lax.cond(
-            do_gibbs_w,
-            lambda kt: gibbs_step_weights(kt[0], kt[1], model, alpha),
-            lambda kt: kt,
-            (key_s, trace_s),
-        )
-        return (key_s, trace_s), None
+        # Always update z and weights
+        key_s, trace_s = mh_step_z(key_s, trace_s, model, sigma)
+        key_s, trace_s = mh_step_weights(key_s, trace_s, model, alpha)
 
-    (key, trace), _ = jax.lax.scan(_step, (key, trace), xs=None, length=n_rounds)
-    return trace
+        # Accumulate running sums with burn-in and thinning
+        ch_s = trace_s.get_choices()
+        take = jnp.logical_and(i >= burn_in, ((i - burn_in) % thin) == 0)
+        sum_w_s = jnp.where(take, sum_w_s + ch_s["weights"], sum_w_s)
+        sum_kd_s = jnp.where(take, sum_kd_s + ch_s["clusters/Kd"], sum_kd_s)
+        sum_n_s = jnp.where(take, sum_n_s + ch_s["clusters/n"], sum_n_s)
+        cnt_s = cnt_s + jnp.where(take, 1, 0)
+
+        return (key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, cnt_s), None
+
+    (key, trace, sum_w, sum_kd, sum_n, count), _ = jax.lax.scan(
+        _step,
+        (key, trace, sum_w, sum_kd, sum_n, count),
+        xs=jnp.arange(n_rounds),
+        length=n_rounds,
+    )
+
+    # Compute posterior means safely
+    denom = jnp.maximum(count.astype(sum_w.dtype), 1)
+    post_means = {
+        "weights": sum_w / denom,
+        "clusters/Kd": sum_kd / denom,
+        "clusters/n": sum_n / denom,
+    }
+
+    return trace, post_means
 
 
 # ------------------------------
@@ -245,7 +305,7 @@ def test_main():
     args = (xs, alpha, 100.0, 5.0, 4.0, 2.0, 0.05)
 
     key, sub = jax.random.split(key)
-    tr_true = mix_hill_vec.simulate(sub, args)
+    tr_true = hill_mixture_model.simulate(sub, args)
     ch_true = tr_true.get_choices()
     print("[truth] weights:", ch_true["weights"])
     print("[truth] Kd:", ch_true["clusters/Kd"])
@@ -255,23 +315,23 @@ def test_main():
     obs = make_obs_from_y(y_obs)
 
     key, sub = jax.random.split(key)
-    tr_post = run_inference_genjax_only(
+    tr_post, post_means = run_inference(
         sub,
-        mix_hill_vec,
+        hill_mixture_model,
         args,
         obs,
         n_rounds=2000,
         mh_step_kd=0.03,
         mh_step_n=0.03,
-        do_gibbs_z=True,
-        do_gibbs_w=True,
+        burn_in=1000,
+        thin=20,
     )
 
     ch = tr_post.get_choices()
-    print("[posterior] weights:", ch["weights"])
-    print("[posterior] Kd     :", ch["clusters/Kd"])
-    print("[posterior] n      :", ch["clusters/n"])
-    print("z head:", ch["z"][:10])
+    print("[posterior mean] weights:", post_means["weights"])
+    print("[posterior mean] Kd     :", post_means["clusters/Kd"])
+    print("[posterior mean] n      :", post_means["clusters/n"])
+    print("z head:", ch["y_mix", "mixture_component"][:10])
 
     assert jnp.all(ch["weights"] >= 0) and jnp.isclose(
         jnp.sum(ch["weights"]), 1.0, atol=1e-4

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -28,8 +28,9 @@ def log_normal_pdf(y, mu, sigma):
 # Components (top-level)
 # ------------------------------
 @gen
-def hill_mu_component(xi, kd, n_k):
+def hill_mu_component(xi, kd, n_k, alpha_k):
     mu = hill(xi, kd, n_k)
+    mu = alpha_k * mu
     return mu
 
 
@@ -45,6 +46,8 @@ def hill_mixture_model(
     shape_n=4.0,
     rate_n=2.0,
     sigma=0.02,
+    shape_alpha=5.0,
+    rate_alpha=5.0,
 ):
     K = 3
 
@@ -52,6 +55,9 @@ def hill_mixture_model(
     w = dirichlet(alpha) @ "weights"  # (K,)
     Kd = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ "clusters/Kd"  # (K,)
     n = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ "clusters/n"  # (K,)
+    Alpha = gamma(
+        shape_alpha, rate_alpha, sample_shape=Const((K,))
+    ) @ "clusters/alpha"  # (K,)
 
     # Build 3-component mixture and vmap over observations
     logits = jnp.log(w + 1e-20)
@@ -59,14 +65,19 @@ def hill_mixture_model(
     mix3_vm = mix3.vmap(
         in_axes=(
             None,  # logits shared across rows
-            (0, None, None),  # args for comp 1: (xs, Kd[0], n[0])
-            (0, None, None),  # args for comp 2
-            (0, None, None),  # args for comp 3
+            (0, None, None, None),  # args for comp 1: (xs, Kd[0], n[0], Alpha[0])
+            (0, None, None, None),  # args for comp 2
+            (0, None, None, None),  # args for comp 3
         )
     )
 
     mu_vec = (
-        mix3_vm(logits, (xs, Kd[0], n[0]), (xs, Kd[1], n[1]), (xs, Kd[2], n[2]))
+        mix3_vm(
+            logits,
+            (xs, Kd[0], n[0], Alpha[0]),
+            (xs, Kd[1], n[1], Alpha[1]),
+            (xs, Kd[2], n[2], Alpha[2]),
+        )
         @ "y_mix"
     )
     y = normal(mu_vec, sigma) @ "y"
@@ -152,15 +163,15 @@ def prop_z(trace, *model_args):
     w = ch["weights"]  # (K,)
     Kd = ch["clusters/Kd"]  # (K,)
     n = ch["clusters/n"]  # (K,)
+    Alpha = ch["clusters/alpha"]  # (K,)
     sigma = model_args[-1]
 
     # Compute per-row logits (N,K)
-    xs_safe = jnp.maximum(xs, 1e-6)
     mu_all = jnp.stack(
         [
-            1.0 / (1.0 + (Kd[0] / xs_safe) ** n[0]),
-            1.0 / (1.0 + (Kd[1] / xs_safe) ** n[1]),
-            1.0 / (1.0 + (Kd[2] / xs_safe) ** n[2]),
+            Alpha[0] * hill(xs, Kd[0], n[0]),
+            Alpha[1] * hill(xs, Kd[1], n[1]),
+            Alpha[2] * hill(xs, Kd[2], n[2]),
         ],
         axis=1,
     )  # (N, K)
@@ -179,8 +190,10 @@ def prop_z(trace, *model_args):
 # ------------------------------
 
 
-def mh_step_globals_rw(key, trace, model, step_kd: float, step_n: float):
-    """One sweep of local RW updates over all clusters for Kd and n.
+def mh_step_globals_rw(
+    key, trace, model, step_kd: float, step_n: float, step_alpha: float
+):
+    """One sweep of local RW updates over all clusters for Kd, n, and alpha.
 
     Proposes in log-space with Normal(0, step^2) increments and includes the
     Hastings correction. Updates K components sequentially using a JAX fori_loop.
@@ -192,6 +205,9 @@ def mh_step_globals_rw(key, trace, model, step_kd: float, step_n: float):
         key_s, trace_s = carry
         key_s, trace_s = _mh_rw_one(key_s, trace_s, model, "clusters/Kd", i, step_kd)
         key_s, trace_s = _mh_rw_one(key_s, trace_s, model, "clusters/n", i, step_n)
+        key_s, trace_s = _mh_rw_one(
+            key_s, trace_s, model, "clusters/alpha", i, step_alpha
+        )
         return (key_s, trace_s)
 
     key, trace = jax.lax.fori_loop(0, K, body, (key, trace))
@@ -254,6 +270,7 @@ def run_inference(
     n_rounds=200,
     mh_step_kd=0.03,
     mh_step_n=0.03,
+    mh_step_alpha=0.03,
     burn_in: int = 0,
     thin: int = 1,
 ):
@@ -267,13 +284,14 @@ def run_inference(
     sum_w = jnp.zeros_like(ch0["weights"])  # (K,)
     sum_kd = jnp.zeros_like(ch0["clusters/Kd"])  # (K,)
     sum_n = jnp.zeros_like(ch0["clusters/n"])  # (K,)
+    sum_alpha = jnp.zeros_like(ch0["clusters/alpha"])  # (K,)
     count = jnp.array(0, dtype=jnp.int32)
 
     def _step(carry, i):
-        key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, cnt_s = carry
+        key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, sum_alpha_s, cnt_s = carry
 
         key_s, trace_s = mh_step_globals_rw(
-            key_s, trace_s, model, mh_step_kd, mh_step_n
+            key_s, trace_s, model, mh_step_kd, mh_step_n, mh_step_alpha
         )
         # Always update z and weights
         key_s, trace_s = mh_step_z(key_s, trace_s, model, sigma)
@@ -285,13 +303,14 @@ def run_inference(
         sum_w_s = jnp.where(take, sum_w_s + ch_s["weights"], sum_w_s)
         sum_kd_s = jnp.where(take, sum_kd_s + ch_s["clusters/Kd"], sum_kd_s)
         sum_n_s = jnp.where(take, sum_n_s + ch_s["clusters/n"], sum_n_s)
+        sum_alpha_s = jnp.where(take, sum_alpha_s + ch_s["clusters/alpha"], sum_alpha_s)
         cnt_s = cnt_s + jnp.where(take, 1, 0)
 
-        return (key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, cnt_s), None
+        return (key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, sum_alpha_s, cnt_s), None
 
-    (key, trace, sum_w, sum_kd, sum_n, count), _ = jax.lax.scan(
+    (key, trace, sum_w, sum_kd, sum_n, sum_alpha, count), _ = jax.lax.scan(
         _step,
-        (key, trace, sum_w, sum_kd, sum_n, count),
+        (key, trace, sum_w, sum_kd, sum_n, sum_alpha, count),
         xs=jnp.arange(n_rounds),
         length=n_rounds,
     )
@@ -302,6 +321,7 @@ def run_inference(
         "weights": sum_w / denom,
         "clusters/Kd": sum_kd / denom,
         "clusters/n": sum_n / denom,
+        "clusters/alpha": sum_alpha / denom,
     }
 
     return trace, post_means
@@ -330,6 +350,7 @@ def test_main():
     print("[truth] weights:", ch_true["weights"])
     print("[truth] Kd:", ch_true["clusters/Kd"])
     print("[truth] n :", ch_true["clusters/n"])
+    print("[truth] alpha :", ch_true["clusters/alpha"])
 
     y_obs = ch_true["y"]
     obs = make_obs_from_y(y_obs)
@@ -351,6 +372,7 @@ def test_main():
     print("[posterior mean] weights:", post_means["weights"])
     print("[posterior mean] Kd     :", post_means["clusters/Kd"])
     print("[posterior mean] n      :", post_means["clusters/n"])
+    print("[posterior mean] alpha  :", post_means["clusters/alpha"])
     print("z head:", ch["y_mix", "mixture_component"][:10])
 
     assert jnp.all(ch["weights"] >= 0) and jnp.isclose(

--- a/tests/test_mix_hill_beta.py
+++ b/tests/test_mix_hill_beta.py
@@ -55,9 +55,9 @@ def hill_mixture_model(
     w = dirichlet(alpha) @ "weights"  # (K,)
     Kd = gamma(shape_kd, rate_kd, sample_shape=Const((K,))) @ "clusters/Kd"  # (K,)
     n = gamma(shape_n, rate_n, sample_shape=Const((K,))) @ "clusters/n"  # (K,)
-    Alpha = gamma(
-        shape_alpha, rate_alpha, sample_shape=Const((K,))
-    ) @ "clusters/alpha"  # (K,)
+    Alpha = (
+        gamma(shape_alpha, rate_alpha, sample_shape=Const((K,))) @ "clusters/alpha"
+    )  # (K,)
 
     # Build 3-component mixture and vmap over observations
     logits = jnp.log(w + 1e-20)
@@ -85,6 +85,12 @@ def hill_mixture_model(
 
 
 # ------------------------------
+# Jitted update for hill_mixture_model
+# ------------------------------
+jitted_update = jax.jit(hill_mixture_model.update)
+
+
+# ------------------------------
 # Proposals
 # ------------------------------
 
@@ -100,7 +106,7 @@ update parameters locally per-cluster and per-parameter to improve acceptance.
 """
 
 
-def _mh_rw_one(key, trace, model, address: str, idx: int, step: float):
+def _mh_rw_one(key, trace, address: str, idx: int, step: float):
     """One MH random-walk update on log-parameter for a single index.
 
     - address: one of "clusters/Kd" or "clusters/n"
@@ -127,7 +133,7 @@ def _mh_rw_one(key, trace, model, address: str, idx: int, step: float):
     prop_cm = prop_cm.at[address].set(prop_vec)
 
     key, sub = jax.random.split(key)
-    new_trace, model_logw, _, _ = model.update(sub, trace, prop_cm, argdiffs)
+    new_trace, model_logw, _, _ = jitted_update(sub, trace, prop_cm, argdiffs)
 
     # Hastings correction for proposing in log-space: log q(x|x') - log q(x'|x) = z' - z
     delta_log_q = z_prop - z_cur
@@ -190,9 +196,7 @@ def prop_z(trace, *model_args):
 # ------------------------------
 
 
-def mh_step_globals_rw(
-    key, trace, model, step_kd: float, step_n: float, step_alpha: float
-):
+def mh_step_globals_rw(key, trace, step_kd: float, step_n: float, step_alpha: float):
     """One sweep of local RW updates over all clusters for Kd, n, and alpha.
 
     Proposes in log-space with Normal(0, step^2) increments and includes the
@@ -203,18 +207,16 @@ def mh_step_globals_rw(
 
     def body(i, carry):
         key_s, trace_s = carry
-        key_s, trace_s = _mh_rw_one(key_s, trace_s, model, "clusters/Kd", i, step_kd)
-        key_s, trace_s = _mh_rw_one(key_s, trace_s, model, "clusters/n", i, step_n)
-        key_s, trace_s = _mh_rw_one(
-            key_s, trace_s, model, "clusters/alpha", i, step_alpha
-        )
+        key_s, trace_s = _mh_rw_one(key_s, trace_s, "clusters/Kd", i, step_kd)
+        key_s, trace_s = _mh_rw_one(key_s, trace_s, "clusters/n", i, step_n)
+        key_s, trace_s = _mh_rw_one(key_s, trace_s, "clusters/alpha", i, step_alpha)
         return (key_s, trace_s)
 
     key, trace = jax.lax.fori_loop(0, K, body, (key, trace))
     return key, trace
 
 
-def mh_step_weights(key, trace, model, alpha):
+def mh_step_weights(key, trace, alpha):
     """Update weights | z via Dirichlet conditional using propose/assess.
     This is a Gibbs-style move; acceptance should be ~1 in theory, but we still
     run the generic MH accept/reject for consistency.
@@ -226,7 +228,7 @@ def mh_step_weights(key, trace, model, alpha):
     fwd_choices, fwd_weight, _ = prop_weights.propose(sub, (trace, *model_args))
 
     key, sub = jax.random.split(key)
-    new_trace, model_logw, _, discard = model.update(sub, trace, fwd_choices, argdiffs)
+    new_trace, model_logw, _, discard = jitted_update(sub, trace, fwd_choices, argdiffs)
 
     bwd_weight, _ = prop_weights.assess(discard, (new_trace, *model_args))
 
@@ -237,7 +239,7 @@ def mh_step_weights(key, trace, model, alpha):
     return key, out_trace
 
 
-def mh_step_z(key, trace, model, sigma):
+def mh_step_z(key, trace, sigma):
     """Update z | rest using collapsed categorical via propose/assess."""
     argdiffs = Diff.no_change(trace.get_args())
     model_args = trace.get_args()
@@ -246,7 +248,7 @@ def mh_step_z(key, trace, model, sigma):
     fwd_choices, fwd_weight, _ = prop_z.propose(sub, (trace, *model_args))
 
     key, sub = jax.random.split(key)
-    new_trace, model_logw, _, discard = model.update(sub, trace, fwd_choices, argdiffs)
+    new_trace, model_logw, _, discard = jitted_update(sub, trace, fwd_choices, argdiffs)
 
     bwd_weight, _ = prop_z.assess(discard, (new_trace, *model_args))
 
@@ -291,11 +293,11 @@ def run_inference(
         key_s, trace_s, sum_w_s, sum_kd_s, sum_n_s, sum_alpha_s, cnt_s = carry
 
         key_s, trace_s = mh_step_globals_rw(
-            key_s, trace_s, model, mh_step_kd, mh_step_n, mh_step_alpha
+            key_s, trace_s, mh_step_kd, mh_step_n, mh_step_alpha
         )
         # Always update z and weights
-        key_s, trace_s = mh_step_z(key_s, trace_s, model, sigma)
-        key_s, trace_s = mh_step_weights(key_s, trace_s, model, alpha)
+        key_s, trace_s = mh_step_z(key_s, trace_s, sigma)
+        key_s, trace_s = mh_step_weights(key_s, trace_s, alpha)
 
         # Accumulate running sums with burn-in and thinning
         ch_s = trace_s.get_choices()

--- a/tests/test_mix_hill_mmm.py
+++ b/tests/test_mix_hill_mmm.py
@@ -1,0 +1,550 @@
+from typing import NamedTuple, Dict, Tuple
+
+import csv
+import collections
+
+import jax
+import jax.numpy as jnp
+from jax import lax, vmap, jit
+
+from genjax import gen, Const  # type: ignore
+from genjax import normal, gamma, dirichlet, mix  # type: ignore
+
+import matplotlib.pyplot as plt
+
+
+# Number of mixture components
+NUM_COMPONENTS = 2
+
+
+# =====================================================
+# Utilities
+# =====================================================
+
+
+def hill(
+    x: jnp.ndarray, kd: jnp.ndarray, n: jnp.ndarray, eps: float = 1e-6
+) -> jnp.ndarray:
+    x = jnp.maximum(x, eps)
+    return 1.0 / (1.0 + (kd / x) ** n)
+
+
+def _safe_log(x: jnp.ndarray, eps: float = 1e-12) -> jnp.ndarray:
+    return jnp.log(jnp.maximum(x, eps))
+
+
+def log_normal_pdf(y, mu, sigma):
+    return -0.5 * (
+        jnp.log(2.0 * jnp.pi) + 2.0 * jnp.log(sigma) + ((y - mu) / sigma) ** 2
+    )
+
+
+# =====================================================
+# Generative model (K fixed, using mix)
+# =====================================================
+
+
+@gen
+def hill_mu_component(xi, kd, n_k):
+    mu = hill(xi, kd, n_k)
+    return mu
+
+
+@gen
+def mix_hill(
+    xs: jnp.ndarray,
+    alpha: jnp.ndarray,  # (NUM_COMPONENTS,)
+    shape_kd: float = 4.0,
+    rate_kd: float = 0.2,
+    shape_n: float = 1.0,
+    rate_n: float = 0.5,
+    sigma: float = 0.05,
+):
+    # Mixture weights
+    weights = dirichlet(alpha) @ "weights"  # (NUM_COMPONENTS,)
+
+    # Cluster parameters (Kd, n)
+    Kd = gamma(shape_kd, rate_kd, sample_shape=Const((NUM_COMPONENTS,))) @ (
+        "clusters",
+        "Kd",
+    )  # (NUM_COMPONENTS,)
+    n = gamma(shape_n, rate_n, sample_shape=Const((NUM_COMPONENTS,))) @ (
+        "clusters",
+        "n",
+    )  # (NUM_COMPONENTS,)
+
+    # Build mixture with mix combinator and vmap over observations
+    logits = jnp.log(weights + 1e-20)  # (NUM_COMPONENTS,)
+    hill_mixture = mix(hill_mu_component, hill_mu_component)
+    hill_mixture_vm = hill_mixture.vmap(
+        in_axes=(
+            None,  # logits shared
+            (0, None, None),  # args for component 1: (xs, Kd[0], n[0])
+            (0, None, None),  # args for component 2: (xs, Kd[1], n[1])
+        )
+    )
+
+    mu_vec = (
+        hill_mixture_vm(
+            logits,
+            (xs, Kd[0], n[0]),
+            (xs, Kd[1], n[1]),
+        )
+        @ "y_mix"
+    )
+
+    # Observations
+    y = normal(mu_vec, sigma) @ "y"
+    return y
+
+
+# =====================================================
+# Collapsed Gibbs for z & Gibbs for weights
+# =====================================================
+
+
+@jit
+def sample_assignments(
+    key: jax.Array,
+    xs: jnp.ndarray,
+    ys: jnp.ndarray,
+    weights: jnp.ndarray,  # (NUM_COMPONENTS,)
+    Kd: jnp.ndarray,  # (NUM_COMPONENTS,)
+    n: jnp.ndarray,  # (NUM_COMPONENTS,)
+    sigma: float,
+) -> Tuple[jax.Array, jnp.ndarray]:
+    def logit_row(xi, yi):
+        mu_k = hill(jnp.full_like(Kd, xi), Kd, n)  # (NUM_COMPONENTS,)
+        ll_k = log_normal_pdf(yi, mu_k, sigma)  # (NUM_COMPONENTS,)
+        return _safe_log(weights) + ll_k
+
+    logits = vmap(logit_row)(xs, ys)  # (N, NUM_COMPONENTS)
+    key, sub = jax.random.split(key)
+    assignments = jax.random.categorical(sub, logits, axis=-1)
+    return key, assignments
+
+
+@jit
+def sample_mixture_weights(
+    key: jax.Array, alpha: jnp.ndarray, assignments: jnp.ndarray
+) -> Tuple[jax.Array, jnp.ndarray]:
+    counts = jnp.bincount(assignments, length=NUM_COMPONENTS).astype(alpha.dtype)
+    key, sub = jax.random.split(key)
+    weights = jax.random.dirichlet(sub, alpha + counts)
+    return key, weights
+
+
+# =====================================================
+# MH for (Kd, n) – log-space RW (mask-based, JIT-friendly)
+# =====================================================
+
+
+class HillMHConfig(NamedTuple):
+    step_kd: float
+    step_n: float
+
+
+def _mh_one_param(key, current, step, logpost_fn):
+    key, sub = jax.random.split(key)
+    prop = current + step * jax.random.normal(sub, ())
+    loga = jnp.minimum(0.0, logpost_fn(prop) - logpost_fn(current))
+    key, sub = jax.random.split(key)
+    accept = jnp.log(jax.random.uniform(sub, ())) < loga
+    new = jnp.where(accept, prop, current)
+    return key, new, accept
+
+
+def _logpost_kd_factory(k: int, xs, ys, z, Kd_log, n_log, sigma, shape_kd, rate_kd):
+    mask = (z == k).astype(ys.dtype)  # (N,)
+
+    def logpost(kd_log_prime):
+        kd_prime = jnp.exp(kd_log_prime)
+        n_k = jnp.exp(n_log[k])
+        log_prior = (shape_kd - 1.0) * kd_log_prime - rate_kd * kd_prime
+
+        mu_all = hill(xs, kd_prime, n_k)  # (N,)
+        ll_all = log_normal_pdf(ys, mu_all, sigma)  # (N,)
+        ll = jnp.sum(mask * ll_all)
+        return log_prior + ll
+
+    return logpost
+
+
+def _logpost_n_factory(k: int, xs, ys, z, Kd_log, n_log, sigma, shape_n, rate_n):
+    mask = (z == k).astype(ys.dtype)  # (N,)
+
+    def logpost(n_log_prime):
+        n_prime = jnp.exp(n_log_prime)
+        kd_k = jnp.exp(Kd_log[k])
+        log_prior = (shape_n - 1.0) * n_log_prime - rate_n * n_prime
+
+        mu_all = hill(xs, kd_k, n_prime)  # (N,)
+        ll_all = log_normal_pdf(ys, mu_all, sigma)  # (N,)
+        ll = jnp.sum(mask * ll_all)
+        return log_prior + ll
+
+    return logpost
+
+
+@jit
+def mh_update_params(
+    key: jax.Array,
+    xs: jnp.ndarray,
+    ys: jnp.ndarray,
+    z: jnp.ndarray,
+    Kd: jnp.ndarray,
+    n: jnp.ndarray,
+    sigma: float,
+    shape_kd: float,
+    rate_kd: float,
+    shape_n: float,
+    rate_n: float,
+    cfg: HillMHConfig,
+) -> Tuple[jax.Array, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    Kd_log = jnp.log(Kd)
+    n_log = jnp.log(n)
+
+    def upd_k(i, carry):
+        key, Kd_log_vec, n_log_vec, acc_kd_vec, acc_n_vec = carry
+
+        key, new_kd_log, acc_kd = _mh_one_param(
+            key,
+            Kd_log_vec[i],
+            cfg.step_kd,
+            _logpost_kd_factory(i, xs, ys, z, Kd_log, n_log, sigma, shape_kd, rate_kd),
+        )
+        Kd_log_vec = Kd_log_vec.at[i].set(new_kd_log)
+
+        key, new_n_log, acc_n = _mh_one_param(
+            key,
+            n_log_vec[i],
+            cfg.step_n,
+            _logpost_n_factory(i, xs, ys, z, Kd_log_vec, n_log, sigma, shape_n, rate_n),
+        )
+        n_log_vec = n_log_vec.at[i].set(new_n_log)
+
+        acc_kd_vec = acc_kd_vec.at[i].add(acc_kd.astype(acc_kd_vec.dtype))
+        acc_n_vec = acc_n_vec.at[i].add(acc_n.astype(acc_n_vec.dtype))
+        return key, Kd_log_vec, n_log_vec, acc_kd_vec, acc_n_vec
+
+    init = (
+        key,
+        Kd_log,
+        n_log,
+        jnp.zeros((NUM_COMPONENTS,)),
+        jnp.zeros((NUM_COMPONENTS,)),
+    )
+    key, Kd_log, n_log, acc_kd, acc_n = lax.fori_loop(0, NUM_COMPONENTS, upd_k, init)
+    return key, jnp.exp(Kd_log), jnp.exp(n_log), acc_kd, acc_n
+
+
+# =====================================================
+# Full MCMC driver
+# =====================================================
+
+
+class HillMMMCMCConfig(NamedTuple):
+    num_iters: int = 3000
+    burn_in: int = 1000
+    thin: int = 10
+    mh_step_kd: float = 0.05
+    mh_step_n: float = 0.05
+
+
+class HillMMMCMCState(NamedTuple):
+    key: jax.Array
+    weights: jnp.ndarray  # (NUM_COMPONENTS,)
+    z: jnp.ndarray  # (N,)
+    Kd: jnp.ndarray  # (NUM_COMPONENTS,)
+    n: jnp.ndarray  # (NUM_COMPONENTS,)
+
+
+@jit
+def mcmc_step(
+    state: HillMMMCMCState,
+    xs: jnp.ndarray,
+    ys: jnp.ndarray,
+    alpha: jnp.ndarray,
+    shape_kd: float,
+    rate_kd: float,
+    shape_n: float,
+    rate_n: float,
+    sigma: float,
+    mh_cfg: HillMHConfig,
+) -> Tuple[HillMMMCMCState, Tuple[jnp.ndarray, jnp.ndarray]]:
+    key = state.key
+
+    # z | rest (collapsed Gibbs)
+    key, z = sample_assignments(key, xs, ys, state.weights, state.Kd, state.n, sigma)
+
+    # w | z (Gibbs)
+    key, w = sample_mixture_weights(key, alpha, z)
+
+    # (Kd, n) | rest (MH)
+    key, Kd_new, n_new, acc_kd, acc_n = mh_update_params(
+        key,
+        xs,
+        ys,
+        z,
+        state.Kd,
+        state.n,
+        sigma,
+        shape_kd,
+        rate_kd,
+        shape_n,
+        rate_n,
+        mh_cfg,
+    )
+
+    new_state = HillMMMCMCState(key, w, z, Kd_new, n_new)
+    return new_state, (acc_kd, acc_n)
+
+
+def run_hill_mmm_mcmc(
+    key: jax.Array,
+    xs: jnp.ndarray,
+    ys: jnp.ndarray,
+    alpha: jnp.ndarray,
+    shape_kd: float,
+    rate_kd: float,
+    shape_n: float,
+    rate_n: float,
+    sigma: float,
+    cfg: HillMMMCMCConfig,
+) -> Dict[str, jnp.ndarray]:
+    # Initialise from prior via GenJAX model
+    key, sub = jax.random.split(key)
+    tr = mix_hill.simulate(sub, (xs, alpha, shape_kd, rate_kd, shape_n, rate_n, sigma))
+    ch = tr.get_choices()
+    w0 = ch["weights"]
+    Kd0 = ch[("clusters", "Kd")]
+    n0 = ch[("clusters", "n")]
+
+    key, z0 = sample_assignments(key, xs, ys, w0, Kd0, n0, sigma)
+    state = HillMMMCMCState(key, w0, z0, Kd0, n0)
+
+    mh_cfg = HillMHConfig(cfg.mh_step_kd, cfg.mh_step_n)
+
+    def one_step(carry, _):
+        st, t, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept = carry
+        st, (acc_kd, acc_n) = mcmc_step(
+            st, xs, ys, alpha, shape_kd, rate_kd, shape_n, rate_n, sigma, mh_cfg
+        )
+        t = t + 1
+
+        def do_keep(args):
+            st, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept = args
+            return (
+                st,
+                sum_w + st.weights,
+                sum_kd + st.Kd,
+                sum_n + st.n,
+                acc_kd_sum + acc_kd,
+                acc_n_sum + acc_n,
+                kept + 1,
+            )
+
+        def no_keep(args):
+            return args
+
+        keep_cond = jnp.logical_and(t > cfg.burn_in, (t - cfg.burn_in) % cfg.thin == 0)
+        st, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept = lax.cond(
+            keep_cond,
+            do_keep,
+            no_keep,
+            operand=(st, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept),
+        )
+
+        return (st, t, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept), None
+
+    init_carry = (
+        state,
+        jnp.array(0, dtype=jnp.int32),
+        jnp.zeros((NUM_COMPONENTS,)),
+        jnp.zeros((NUM_COMPONENTS,)),
+        jnp.zeros((NUM_COMPONENTS,)),
+        jnp.zeros((NUM_COMPONENTS,)),
+        jnp.zeros((NUM_COMPONENTS,)),
+        jnp.array(0, dtype=jnp.int32),
+    )
+
+    (st, t, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept), _ = lax.scan(
+        one_step, init_carry, xs=jnp.arange(cfg.num_iters)
+    )
+
+    kept = jnp.maximum(kept, 1)
+    post_w = sum_w / kept
+    post_kd = sum_kd / kept
+    post_n = sum_n / kept
+    acc_kd_rate = acc_kd_sum / jnp.maximum(cfg.num_iters, 1)
+    acc_n_rate = acc_n_sum / jnp.maximum(cfg.num_iters, 1)
+
+    return dict(
+        post_w=post_w,
+        post_kd=post_kd,
+        post_n=post_n,
+        acc_kd=acc_kd_rate,
+        acc_n=acc_n_rate,
+        last_state=st,
+    )
+
+
+run_hill_mmm_mcmc_jit = jit(run_hill_mmm_mcmc, static_argnames=("cfg",))
+
+
+# =====================================================
+# MMM experiment: fit each group in mmm.csv and plot
+# =====================================================
+
+
+def _load_mmm_groups():
+    groups = collections.defaultdict(lambda: {"xs": [], "ys": []})
+    with open("tests/data/mmm.csv", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            key = (
+                row["ORGANISATION_SUBVERTICAL"],
+                row["TERRITORY_NAME"],
+                row["MARKETING_CHANNEL"],
+            )
+            groups[key]["xs"].append(float(row["SPEND"]))
+            groups[key]["ys"].append(float(row["CLICKS"]))
+    return groups
+
+
+def _plot_group_mmm(xs, ys, out, title, out_png, y_scale: float):
+    # xs, ys are original (unscaled) data; out is posterior summary on scaled ys
+    xs_line = jnp.linspace(float(xs.min()), float(xs.max()), 400)
+
+    # Collect additional samples from last_state to estimate component std
+    st = out["last_state"]
+    alpha = jnp.ones(NUM_COMPONENTS)
+    shape_kd = 4.0
+    rate_kd = 0.2
+    shape_n = 1.0
+    rate_n = 0.5
+    sigma = 0.05
+    mh_cfg = HillMHConfig(0.03, 0.03)
+
+    n_draws = 200
+    mu_samples = jnp.zeros((n_draws, NUM_COMPONENTS, xs_line.shape[0]))
+
+    def body(carry, i):
+        st, mu_s = carry
+        st, _ = mcmc_step(
+            st,
+            xs,
+            ys / y_scale,
+            alpha,
+            shape_kd,
+            rate_kd,
+            shape_n,
+            rate_n,
+            sigma,
+            mh_cfg,
+        )
+        for k in range(NUM_COMPONENTS):
+            mu_k = hill(xs_line, st.Kd[k], st.n[k]) * y_scale
+            mu_s = mu_s.at[i, k, :].set(mu_k)
+        return (st, mu_s), None
+
+    (st_final, mu_samples), _ = lax.scan(body, (st, mu_samples), xs=jnp.arange(n_draws))
+
+    mu_mean = mu_samples.mean(axis=0)  # (NUM_COMPONENTS, n_x)
+    mu_std = mu_samples.std(axis=0)  # (NUM_COMPONENTS, n_x)
+
+    # Sort xs_line for plotting
+    order = jnp.argsort(xs_line)
+    xs_plot = xs_line[order]
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.scatter(xs, ys, s=10, color="orange", edgecolors="none", label="data")
+
+    # Plot each component curve with ±3σ band; weight affects opacity
+    post_w = out["post_w"]
+    order_k = list(jnp.argsort(post_w))
+    for idx, k in enumerate(order_k):
+        k = int(k)
+        w_k = float(post_w[k])
+        alpha_k = float(0.2 + 0.8 * max(0.0, min(1.0, w_k)))
+        mean_k = mu_mean[k][order]
+        std_k = mu_std[k][order]
+
+        ax.fill_between(
+            xs_plot,
+            mean_k - 3.0 * std_k,
+            mean_k + 3.0 * std_k,
+            color="black",
+            alpha=0.12 * alpha_k,
+            label="component ±3σ" if idx == 0 else None,
+        )
+        ax.plot(
+            xs_plot,
+            mean_k,
+            color="black",
+            linewidth=2,
+            alpha=alpha_k,
+            label="post mean (weighted)" if idx == len(order_k) - 1 else None,
+        )
+
+    ax.set_xlabel("SPEND")
+    ax.set_ylabel("CLICKS")
+    ax.set_title(title)
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_png, dpi=150)
+    plt.close(fig)
+
+
+def test_mmm_mixture_hill():
+    key = jax.random.PRNGKey(0)
+    groups = _load_mmm_groups()
+
+    for (subv, terr, chn), data in groups.items():
+        xs = jnp.array(data["xs"])
+        ys = jnp.array(data["ys"])
+
+        # Scale clicks to [0,1] range for stable hill modelling, then scale back
+        y_scale = float(jnp.max(ys))
+        ys_scaled = ys / y_scale
+
+        alpha = jnp.ones(NUM_COMPONENTS)
+
+        # Priors roughly matching the synthetic demo but allowing broader Kd
+        shape_kd = 4.0
+        rate_kd = 0.2
+        shape_n = 1.0
+        rate_n = 0.5
+        sigma = 0.05
+
+        cfg = HillMMMCMCConfig(
+            num_iters=3000,
+            burn_in=0,
+            thin=5,
+            mh_step_kd=0.03,
+            mh_step_n=0.03,
+        )
+
+        key, sub = jax.random.split(key)
+        out = run_hill_mmm_mcmc_jit(
+            sub,
+            xs,
+            ys_scaled,
+            alpha=alpha,
+            shape_kd=shape_kd,
+            rate_kd=rate_kd,
+            shape_n=shape_n,
+            rate_n=rate_n,
+            sigma=sigma,
+            cfg=cfg,
+        )
+
+        title = f"{subv} | {terr} | {chn}"
+        safe_subv = subv.replace(" ", "_")
+        safe_terr = terr.replace(" ", "_")
+        safe_chn = chn.replace(" ", "_")
+        out_png = (
+            f"mix_hill_mmm_{safe_subv}_{safe_terr}_{safe_chn}_K{NUM_COMPONENTS}.png"
+        )
+
+        _plot_group_mmm(xs, ys, out, title, out_png, y_scale=y_scale)

--- a/tests/test_mix_hill_mmm.py
+++ b/tests/test_mix_hill_mmm.py
@@ -1,4 +1,4 @@
-from typing import NamedTuple, Dict, Tuple
+from typing import NamedTuple, Dict, Tuple, Any
 
 import csv
 import collections
@@ -9,6 +9,8 @@ from jax import lax, vmap, jit
 
 from genjax import gen, Const  # type: ignore
 from genjax import normal, gamma, dirichlet, mix  # type: ignore
+from genjax import ChoiceMapBuilder as C  # type: ignore
+from genjax._src.core.compiler.interpreters.incremental import Diff  # type: ignore
 
 import matplotlib.pyplot as plt
 
@@ -63,14 +65,14 @@ def mix_hill(
     # Mixture weights
     weights = dirichlet(alpha) @ "weights"  # (NUM_COMPONENTS,)
 
-    # Cluster parameters (Kd, n)
-    Kd = gamma(shape_kd, rate_kd, sample_shape=Const((NUM_COMPONENTS,))) @ (
-        "clusters",
-        "Kd",
+    # Cluster parameters (Kd, n). Use flat string addresses to keep
+    # trace subtraces using only string keys (avoids JAX PyTree dict
+    # key sorting issues when jitting over traces).
+    Kd = (
+        gamma(shape_kd, rate_kd, sample_shape=Const((NUM_COMPONENTS,))) @ "clusters/Kd"
     )  # (NUM_COMPONENTS,)
-    n = gamma(shape_n, rate_n, sample_shape=Const((NUM_COMPONENTS,))) @ (
-        "clusters",
-        "n",
+    n = (
+        gamma(shape_n, rate_n, sample_shape=Const((NUM_COMPONENTS,))) @ "clusters/n"
     )  # (NUM_COMPONENTS,)
 
     # Build mixture with mix combinator and vmap over observations
@@ -253,10 +255,7 @@ class HillMMMCMCConfig(NamedTuple):
 
 class HillMMMCMCState(NamedTuple):
     key: jax.Array
-    weights: jnp.ndarray  # (NUM_COMPONENTS,)
-    z: jnp.ndarray  # (N,)
-    Kd: jnp.ndarray  # (NUM_COMPONENTS,)
-    n: jnp.ndarray  # (NUM_COMPONENTS,)
+    trace: Any
 
 
 @jit
@@ -273,21 +272,40 @@ def mcmc_step(
     mh_cfg: HillMHConfig,
 ) -> Tuple[HillMMMCMCState, Tuple[jnp.ndarray, jnp.ndarray]]:
     key = state.key
+    trace = state.trace
 
-    # z | rest (collapsed Gibbs)
-    key, z = sample_assignments(key, xs, ys, state.weights, state.Kd, state.n, sigma)
+    # Current choices from trace
+    ch = trace.get_choices()
+    weights = ch["weights"]
+    Kd = ch["clusters/Kd"]
+    n = ch["clusters/n"]
 
-    # w | z (Gibbs)
+    # z | rest (collapsed Gibbs) then update trace
+    key, z = sample_assignments(key, xs, ys, weights, Kd, n, sigma)
+    argdiffs = Diff.no_change(trace.get_args())
+    key, sub = jax.random.split(key)
+    trace, _, _, _ = trace.update(sub, C["y_mix", "mixture_component"].set(z), argdiffs)
+
+    # w | z (Gibbs) then update trace
+    ch = trace.get_choices()
+    z = ch["y_mix", "mixture_component"]
     key, w = sample_mixture_weights(key, alpha, z)
+    argdiffs = Diff.no_change(trace.get_args())
+    key, sub = jax.random.split(key)
+    trace, _, _, _ = trace.update(sub, C["weights"].set(w), argdiffs)
 
-    # (Kd, n) | rest (MH)
+    # (Kd, n) | rest (MH) then update trace
+    ch = trace.get_choices()
+    z = ch["y_mix", "mixture_component"]
+    Kd = ch["clusters/Kd"]
+    n = ch["clusters/n"]
     key, Kd_new, n_new, acc_kd, acc_n = mh_update_params(
         key,
         xs,
         ys,
         z,
-        state.Kd,
-        state.n,
+        Kd,
+        n,
         sigma,
         shape_kd,
         rate_kd,
@@ -295,8 +313,12 @@ def mcmc_step(
         rate_n,
         mh_cfg,
     )
+    argdiffs = Diff.no_change(trace.get_args())
+    key, sub = jax.random.split(key)
+    cm_update = C["clusters/Kd"].set(Kd_new) | C["clusters/n"].set(n_new)
+    trace, _, _, _ = trace.update(sub, cm_update, argdiffs)
 
-    new_state = HillMMMCMCState(key, w, z, Kd_new, n_new)
+    new_state = HillMMMCMCState(key, trace)
     return new_state, (acc_kd, acc_n)
 
 
@@ -312,16 +334,13 @@ def run_hill_mmm_mcmc(
     sigma: float,
     cfg: HillMMMCMCConfig,
 ) -> Dict[str, jnp.ndarray]:
-    # Initialise from prior via GenJAX model
+    # Initialise trace via GenJAX model conditioned on observations
     key, sub = jax.random.split(key)
-    tr = mix_hill.simulate(sub, (xs, alpha, shape_kd, rate_kd, shape_n, rate_n, sigma))
-    ch = tr.get_choices()
-    w0 = ch["weights"]
-    Kd0 = ch[("clusters", "Kd")]
-    n0 = ch[("clusters", "n")]
-
-    key, z0 = sample_assignments(key, xs, ys, w0, Kd0, n0, sigma)
-    state = HillMMMCMCState(key, w0, z0, Kd0, n0)
+    obs = C["y"].set(ys)
+    trace, _ = mix_hill.importance(
+        sub, obs, (xs, alpha, shape_kd, rate_kd, shape_n, rate_n, sigma)
+    )
+    state = HillMMMCMCState(key, trace)
 
     mh_cfg = HillMHConfig(cfg.mh_step_kd, cfg.mh_step_n)
 
@@ -334,11 +353,12 @@ def run_hill_mmm_mcmc(
 
         def do_keep(args):
             st, sum_w, sum_kd, sum_n, acc_kd_sum, acc_n_sum, kept = args
+            ch = st.trace.get_choices()
             return (
                 st,
-                sum_w + st.weights,
-                sum_kd + st.Kd,
-                sum_n + st.n,
+                sum_w + ch["weights"],
+                sum_kd + ch["clusters/Kd"],
+                sum_n + ch["clusters/n"],
                 acc_kd_sum + acc_kd,
                 acc_n_sum + acc_n,
                 kept + 1,
@@ -443,8 +463,10 @@ def _plot_group_mmm(xs, ys, out, title, out_png, y_scale: float):
             sigma,
             mh_cfg,
         )
+        ch = st.trace.get_choices()
         for k in range(NUM_COMPONENTS):
-            mu_k = hill(xs_line, st.Kd[k], st.n[k]) * y_scale
+            mu_k = hill(xs_line, ch["clusters/Kd"][k], ch["clusters/n"][k])
+            mu_k = mu_k * y_scale
             mu_s = mu_s.at[i, k, :].set(mu_k)
         return (st, mu_s), None
 


### PR DESCRIPTION
This is the second proposal addressing Issue #20.
It implements the same Mixture of Hill functions (K=3) model, but the inference part is rewritten using GenJAX-native combinators instead of pure JAX loops.

Design follows the same structure as Proposal 1

Inference logic uses model.update, ChoiceMap, and GenJAX’s incremental update mechanisms

Conducted tests on synthetic data only (MMM dataset not yet applied)

⚠️ Current issues:

Runs successfully, but memory usage grows rapidly

Execution time is about 100× slower than the JAX-only version (~8 min vs ~4 sec)

Optimization and batching of updates are needed

Test result:
```
pytest -s  tests/test_mix_hill_beta.py
==================================================== test session starts =====================================================
platform darwin -- Python 3.13.0, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/shoheiyoshida/dev/genjax-examples
configfile: pyproject.toml
plugins: jaxtyping-0.2.38
collected 1 item                                                                                                             

tests/test_mix_hill_beta.py [truth] weights: [0.13646618 0.10860431 0.7549295 ]
[truth] Kd: [17.861517 17.865307 19.368885]
[truth] n : [1.4813616 3.3177345 0.9608195]
 python(9839,0x175397000) malloc: Failed to allocate segment from range group - out of space
[posterior] weights: [0.26726905 0.27509758 0.45763344]
[posterior] Kd     : [18.589779 18.377907 19.665384]
[posterior] n      : [3.1260295 1.4429562 0.9343963]
z head: [2 0 0 1 1 2 1 2 2 2]
.

=============================================== 1 passed in 515.28s (0:08:35) ================================================

```